### PR TITLE
Fix Error thrown when calling `new Iterator()`

### DIFF
--- a/rpc-fs.js
+++ b/rpc-fs.js
@@ -120,7 +120,7 @@
       callback(error, dirStats);
     } 
 
-    filesIterator = new Iterator();
+    filesIterator = Iterator();
 
     filesIterator.next();
 


### PR DESCRIPTION
The latest Chrome and Firefox do not allow you to declare `new` on a Generator. Therefor the code `new Iterator()` on line 123 is throwing an error. This fix simply removes the `new`. I tested this fix with the `fs-rsync` demo, everything is working nicely :)